### PR TITLE
fix: stb_image not found during compilation

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(KosmicEngine
     src/Assets/Material.cpp
 )
 
-target_include_directories(KosmicEngine PUBLIC 
+target_include_directories(KosmicEngine PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
@@ -25,6 +25,7 @@ target_link_libraries(KosmicEngine PUBLIC
     glm::glm
     ImGui
     assimp
+    stb
 )
 
 if(WIN32)

--- a/Engine/src/Renderer/Texture.cpp
+++ b/Engine/src/Renderer/Texture.cpp
@@ -1,7 +1,7 @@
 #include "Kosmic/Renderer/Texture.hpp"
 #include <GL/glew.h>
 #define STB_IMAGE_IMPLEMENTATION
-#include "stb/stb_image.h"
+#include <stb_image.h>
 #include "Kosmic/Core/Logging.hpp"
 
 namespace Kosmic::Renderer {


### PR DESCRIPTION
stb_image.h is not being correctly searched inside your cmake. You probably have it installed in your system so it does not give you a compilation error, but it crashes on my computer. This PR fixes it.