### PR TITLE
fix: spdlog header & feat: use ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(KosmicEngine
     LANGUAGES CXX
 )
 
+# Use ccache to speed up compilation
+set(CMAKE_C_COMPILER_LAUNCHER ccache)
+set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Use ccache to speed up compilation
+set(CMAKE_C_COMPILER_LAUNCHER ccache)
+set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+
 find_package(GLEW REQUIRED)
 find_package(glm REQUIRED)
 

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(KosmicEngine PUBLIC
     ImGui
     assimp
     stb
+    spdlog::spdlog
 )
 
 if(WIN32)

--- a/Sandbox/CMakeLists.txt
+++ b/Sandbox/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Use ccache to speed up compilation
+set(CMAKE_C_COMPILER_LAUNCHER ccache)
+set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+
 add_executable(Sandbox src/main.cpp)
 
 target_link_libraries(Sandbox PRIVATE

--- a/Thirdparty/CMakeLists.txt
+++ b/Thirdparty/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Use ccache to speed up compilation
+set(CMAKE_C_COMPILER_LAUNCHER ccache)
+set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+
 # Propagate build type to dependencies
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(DEBUG)


### PR DESCRIPTION
- Use `ccache` to reduce build time
- Fix spdlog header not found